### PR TITLE
removed aws config file & refs in docker/readme

### DIFF
--- a/.aws/config
+++ b/.aws/config
@@ -1,2 +1,0 @@
-[default]
-region = eu-central-1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 services:
 - docker
 env:
-  global:
+  global:x
   - GO111MODULE=on
   - DOCKER_USERNAME=altemistatravis
   - DOCKER_NS=altemista
@@ -22,7 +22,6 @@ cache:
 install:
   - go mod download
   - mkdir -p $HOME/.aws
-  - cp .aws/config $HOME/.aws/config
   - docker pull $TAG_LATEST
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 services:
 - docker
 env:
-  global:x
+  global:
   - GO111MODULE=on
   - DOCKER_USERNAME=altemistatravis
   - DOCKER_NS=altemista
@@ -21,7 +21,6 @@ cache:
   - $HOME/gopath/pkg/mod
 install:
   - go mod download
-  - mkdir -p $HOME/.aws
   - docker pull $TAG_LATEST
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ FROM alpine
 RUN apk add ca-certificates
 # Create non-root user
 RUN adduser -D runner
-# Add AWS config to user
-COPY .aws/config /home/runner/.aws/config
 # Set variable enabling loading of the config
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -38,13 +38,7 @@ provider: aws
 
 ## AWS Auth and Config <a name="awsauthconfig"></a>
 
-The Application will look for `~/.aws/config` and `~/.aws/credentials` on your machine.
-
-You can copy the default config included in this repository, and adapt it to your needs.
-```shell
-cp -r ./.aws/config ~/.aws/config
-```
-
+The Application will look for and `~/.aws/credentials` on your machine.
 
 You will have to provide your own credentials file or use IAM Roles / Environment variables. You can read more about it here:
 [AWS - Configuring sdk](https://docs.aws.amazon.com/de_de/sdk-for-go/v1/developer-guide/configuring-sdk.html)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ provider: aws
 
 ## AWS Auth and Config <a name="awsauthconfig"></a>
 
-The Application will look for and `~/.aws/credentials` on your machine.
+The Application will look for `~/.aws/credentials` on your machine.
 
 You will have to provide your own credentials file or use IAM Roles / Environment variables. You can read more about it here:
 [AWS - Configuring sdk](https://docs.aws.amazon.com/de_de/sdk-for-go/v1/developer-guide/configuring-sdk.html)


### PR DESCRIPTION
As the AWS config is now generated by our own library code instead of an external file the user/container has to copy, the .aws/config file is no longer required