### PR TITLE
UploadGroup channel rework, localstore func added

### DIFF
--- a/cmd/invoice.go
+++ b/cmd/invoice.go
@@ -16,6 +16,7 @@ var (
 	provider string
 	bucket   string
 	margin   float64
+	local    bool
 	// invoiceCmd represents the createBill command
 	invoiceCmd = &cobra.Command{
 		Use:   "invoice",
@@ -29,17 +30,15 @@ var (
 
 func init() {
 
-	// month flag & config
 	invoiceCmd.Flags().StringVarP(&month, "month", "m", "current", "Specifies the month: current, last, or 'YYYY-MM'")
 
-	// provider flag & config
 	invoiceCmd.Flags().StringVar(&provider, "provider", "aws", "Specifies the API to work with: aws, azure or onpremise")
 
-	// bucket flag & config
 	invoiceCmd.Flags().StringVarP(&bucket, "bucket", "b", "", "S3 bucket for output documents (required) ")
 	invoiceCmd.MarkFlagRequired("bucket")
 
-	// margin flag & config
+	invoiceCmd.Flags().BoolVarP(&local, "local", "l", false, "Saves files to local disk instead of uploading to S3. Overrides bucket param.")
+
 	invoiceCmd.Flags().Float64Var(&margin, "margin", 0.00, "The relative margin that should be added on top of resource costs as ops compensation")
 
 	rootCmd.AddCommand(invoiceCmd)
@@ -64,7 +63,7 @@ func invoice() {
 	}
 
 	// Flag and arg parsing complete, pass to application code
-	err = cmd.Invoice(parsedProvider, parsedMonth, margin, bucket)
+	err = cmd.Invoice(parsedProvider, parsedMonth, margin, bucket, local)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestUpload(t *testing.T) {
-	_, err := Upload("test", "altemista-billing-travis", "test/invoice", ".csv", time.Now())
+	_, err := Upload("test", "altemista-billing-travis", "test/invoice", time.Now())
 	if err != nil {
 		log.Println("Writing to s3 failed: ", err)
 		t.FailNow()

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"log"
-	"os"
 	"testing"
 	"time"
 
@@ -10,10 +9,6 @@ import (
 )
 
 func TestUpload(t *testing.T) {
-	if _, exists := os.LookupEnv("AWS_SDK_LOAD_CONFIG=1"); !exists {
-		t.Skip("Tried to test uploading to S3, but no valid AWS config found. Test skipped.")
-	}
-
 	_, err := Upload("test", "altemista-billing-travis", "test/invoice", ".csv", time.Now())
 	if err != nil {
 		log.Println("Writing to s3 failed: ", err)


### PR DESCRIPTION
Goals:
 - [x] Make the interface of UploadGroup more ergonomic and straightforward to use
 - [x] Add option to store on local drive as requested by #54 
 - [x] Add command line flag for using local storage instead of s3 (useful for dev, debugging)
