### PR TITLE
Skip integration test if no credentials available

### DIFF
--- a/pkg/billing/aws_test.go
+++ b/pkg/billing/aws_test.go
@@ -4,9 +4,25 @@ import (
 	"log"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
 )
 
 func TestAWS(t *testing.T) {
+	// no parameters will look for credentials file at awscli default location
+	credsFile := credentials.NewSharedCredentials("", "")
+	credsEnv := credentials.NewEnvCredentials()
+	if credsFile == nil || credsEnv == nil {
+		log.Println("AWS unexpectedly returned a nil pointer")
+		t.SkipNow()
+	}
+	_, errFileCreds := credsFile.Get()
+	_, errCredsEnv := credsEnv.Get()
+	if errFileCreds != nil && errCredsEnv != nil {
+		log.Println("Skipping Test because Creds could be retrieved neither from file or env.")
+		t.SkipNow()
+	}
+
 	const iso8601 = "2006-01-02"
 	provider := AWS()
 	month := "2019-04-01"

--- a/pkg/billing/billing_test.go
+++ b/pkg/billing/billing_test.go
@@ -74,7 +74,3 @@ func TestApplyMargin(t *testing.T) {
 
 	}
 }
-
-// func TestToChargeBack(t *testing.T) {
-
-// }

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestUpload(t *testing.T) {
-	// no parameters will look for credentials file
+	// no parameters will look for credentials file at awscli default location
 	credsFile := credentials.NewSharedCredentials("", "")
 	credsEnv := credentials.NewEnvCredentials()
 	if credsFile == nil || credsEnv == nil {
@@ -21,7 +21,7 @@ func TestUpload(t *testing.T) {
 	_, errFileCreds := credsFile.Get()
 	_, errCredsEnv := credsEnv.Get()
 	if errFileCreds != nil && errCredsEnv != nil {
-		log.Println("Skipping TestUpload because Creds could be retrieved neither from file or env.")
+		log.Println("Skipping Test because Creds could be retrieved neither from file or env.")
 		t.SkipNow()
 	}
 

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -2,16 +2,27 @@ package store
 
 import (
 	"log"
-	"os"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
 
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestUpload(t *testing.T) {
-	if _, exists := os.LookupEnv("AWS_SDK_LOAD_CONFIG=1"); !exists {
-		t.Skip("Tried to test uploading to S3, but no valid AWS config found. Test skipped.")
+	// no parameters will look for credentials file
+	credsFile := credentials.NewSharedCredentials("", "")
+	credsEnv := credentials.NewEnvCredentials()
+	if credsFile == nil || credsEnv == nil {
+		log.Println("AWS unexpectedly returned a nil pointer")
+		t.SkipNow()
+	}
+	_, errFileCreds := credsFile.Get()
+	_, errCredsEnv := credsEnv.Get()
+	if errFileCreds != nil && errCredsEnv != nil {
+		log.Println("Skipping TestUpload because Creds could be retrieved neither from file or env.")
+		t.SkipNow()
 	}
 
 	_, err := Upload("test", "altemista-billing-travis", "test/invoice", ".csv", time.Now())


### PR DESCRIPTION
### Description
Currently, `go test ./...` fails if no valid AWS credential providers are available. This PR aims to change this behaviour to skip integrations test / tests requiring credentials if no credentials are available and only run unit tests.


### Related issues:
#61 